### PR TITLE
Added force parameter to allow overwriting files

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function copyDereference () {
 }
 
 module.exports.sync = copyDereferenceSync
-function copyDereferenceSync (src, dest) {
+function copyDereferenceSync (src, dest, force) {
   // We could try readdir'ing and catching ENOTDIR exceptions, but that is 3x
   // slower than stat'ing in the common case that we have a file.
   var srcStats = fs.statSync(src)
@@ -16,14 +16,26 @@ function copyDereferenceSync (src, dest) {
     // mkdirSync, because we wouldn't be able to populate read-only
     // directories. If we really wanted to preserve directory modes, we could
     // call chmodSync at the end.
-    fs.mkdirSync(dest)
+    if(force === true) {
+      try {
+        fs.mkdirSync(dest)
+      } catch(e) {
+        if ( e.code != 'EEXIST' ) throw e;
+      }
+    } else {
+      fs.mkdirSync(dest);
+    }
     var entries = fs.readdirSync(src).sort()
     for (var i = 0; i < entries.length; i++) {
-      copyDereferenceSync(src + path.sep + entries[i], dest + path.sep + entries[i])
+      copyDereferenceSync(src + path.sep + entries[i], dest + path.sep + entries[i], force)
     }
   } else if (srcStats.isFile()) {
     var contents = fs.readFileSync(src)
-    fs.writeFileSync(dest, contents, { flag: 'wx', mode: srcStats.mode })
+    if(force === true) {
+      fs.writeFileSync(dest, contents, { flag: 'w', mode: srcStats.mode })
+    } else {
+      fs.writeFileSync(dest, contents, { flag: 'wx', mode: srcStats.mode })
+    }
   } else {
     throw new Error('Unexpected file type for ' + src)
   }


### PR DESCRIPTION
I think it would be a very useful addition for broccoli-cli to have a `--force` flag for `broccoli build dist`, so you don't always have to manually delete the folder. 
Another use-case would be for adding a watch flag to the cli: `broccoli build --watch`.
This addition would allow for such behaviour to be added, while keeping the old behaviour in place. It just adds the possibility of a third parameter to be `true/false`. 
If it is false or undefined, we have the original behaviour.
If it is true, then the potential `EEXIST` error from `mkdirSync` gets ignored and files get written with the `w` flag instead of `wx`.
