### PR TITLE
don’t try to create directories that already exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,16 @@ function copyDereferenceSync (src, dest) {
     // mkdirSync, because we wouldn't be able to populate read-only
     // directories. If we really wanted to preserve directory modes, we could
     // call chmodSync at the end.
-    fs.mkdirSync(dest)
+    var destIsDir = false
+
+    try {
+      destIsDir = fs.statSync(dest).isDirectory()
+    } catch(e) { }
+
+    if (!destIsDir) {
+      fs.mkdirSync(dest)
+    }
+
     var entries = fs.readdirSync(src).sort()
     for (var i = 0; i < entries.length; i++) {
       copyDereferenceSync(src + path.sep + entries[i], dest + path.sep + entries[i])

--- a/package.json
+++ b/package.json
@@ -9,6 +9,5 @@
     "type": "git",
     "url": "https://github.com/broccolijs/node-copy-dereference"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
In the scenario were you want to maintain the directory for long-lived symlinks to directories, error if they are present causes grief.

For the above mentioned scenario, typically only the root directory needs to remain stable, This PR repeats the behavior for all nested dirs. This is fixable, but depends on the maintainers solution preference. Some flag / options could be used to declare intent.

As ncp is broken on iojs, moving to copy-deference quickly fixed this (with the patch contained in this PR), as we want to move forward a temporary fork exists until ^^, or some future incarnation, lands https://github.com/ember-cli/node-copy-dereference https://www.npmjs.com/package/ember-cli-copy-dereference
