### PR TITLE
Use fs.copyFileSync if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,12 @@ function copyDereferenceSync (src, dest) {
       copyDereferenceSync(src + path.sep + entries[i], dest + path.sep + entries[i])
     }
   } else if (srcStats.isFile()) {
-    var contents = fs.readFileSync(src)
-    fs.writeFileSync(dest, contents, { flag: 'wx', mode: srcStats.mode })
+    if (fs.copyFileSync) {
+      fs.copyFileSync(src, dest, fs.constants.COPYFILE_EXCL)
+    } else {
+      var contents = fs.readFileSync(src)
+      fs.writeFileSync(dest, contents, { flag: 'wx', mode: srcStats.mode })
+    }
   } else {
     throw new Error('Unexpected file type for ' + src)
   }


### PR DESCRIPTION
More efficient copying with node >= 8.5

See: https://nodejs.org/en/blog/release/v8.5.0/
Yarn had huge improvements with `fs.copyFile`: https://github.com/yarnpkg/yarn/pull/4486